### PR TITLE
🎨 style: 차단 OPU 목록 페이지 스타일 수정 #65

### DIFF
--- a/opu-fe/src/features/blocked-opu/components/BlockedOpuCard.tsx
+++ b/opu-fe/src/features/blocked-opu/components/BlockedOpuCard.tsx
@@ -54,65 +54,68 @@ export default function BlockedOpuCard({
 
     return (
         <div
-            className="flex items-start gap-2 cursor-pointer"
-            onClick={toggleChecked} // ← 카드 전체 클릭 토글
+            className="flex items-start gap-1 cursor-pointer"
+            onClick={toggleChecked}
         >
             {selectable && (
                 <input
                     type="checkbox"
-                    className="custom-checkbox shrink-0 ml-2"
+                    className="custom-checkbox shrink-0 ml-1"
                     checked={checked}
                     onChange={(e) =>
                         onCheckedChange?.(item.id, e.target.checked)
                     }
-                    onClick={(e) => e.stopPropagation()} // ← 카드 클릭 방지
+                    onClick={(e) => e.stopPropagation()} // 카드 클릭 방지
                     aria-label={`${item.title} 선택`}
                 />
             )}
 
             <div className="w-full bg-[var(--background)]">
-                <div className="ml-2">
-                    <div className="grid grid-cols-[50px_1fr_auto] items-start gap-4">
-                        <div
-                            className="flex items-center justify-center rounded-md"
-                            style={{
-                                width: 50,
-                                height: 50,
-                                backgroundColor: "#F1F1F1",
-                            }}
-                        >
-                            {item.emoji ?? "❓"}
+                <div className="ml-1">
+                    <div className="flex items-start gap-3">
+                        <div className="flex items-center justify-center p-1 bg-[var(--color-opu-yellow)] rounded-2xl mb-1">
+                            <span
+                                className="flex items-center justify-center shrink-0"
+                                style={{
+                                    fontSize: "var(--text-h2)",
+                                    width: 30,
+                                    height: 30,
+                                }}
+                            >
+                                {item.emoji ?? "❓"}
+                            </span>
                         </div>
 
-                        <div className="min-w-0">
-                            <div className="flex justify-between">
-                                <p className="text-[var(--text-body)] font-[var(--weight-medium)]">
+                        <div className="w-full flex flex-col gap-1">
+                            <div className="flex items-start justify-between">
+                                <p
+                                    style={{
+                                        fontSize: "var(--text-sub)",
+                                        fontWeight: "var(--weight-medium)",
+                                    }}
+                                >
                                     {item.title}
                                 </p>
-
-                                <div className="relative">
-                                    <button
-                                        type="button"
-                                        aria-haspopup="menu"
-                                        aria-expanded={menuOpen}
-                                        onClick={(e) => {
-                                            e.stopPropagation(); // ← 카드 선택 방지
-                                            onMore?.(item.id);
-                                            setMenuOpen((v) => !v);
+                                <button
+                                    type="button"
+                                    aria-haspopup="menu"
+                                    aria-expanded={menuOpen}
+                                    onClick={(e) => {
+                                        e.stopPropagation(); // ← 카드 선택 방지
+                                        onMore?.(item.id);
+                                        setMenuOpen((v) => !v);
+                                    }}
+                                    title="더보기"
+                                >
+                                    <Icon
+                                        icon="lucide:ellipsis"
+                                        width={17}
+                                        height={17}
+                                        style={{
+                                            color: "var(--color-super-dark-gray)",
                                         }}
-                                        className="inline-flex shrink-0 -mx-2"
-                                        title="더보기"
-                                    >
-                                        <Icon
-                                            icon="lucide:ellipsis"
-                                            width={17}
-                                            height={17}
-                                            style={{
-                                                color: "var(--color-super-dark-gray)",
-                                            }}
-                                        />
-                                    </button>
-                                </div>
+                                    />
+                                </button>
                             </div>
 
                             <div className="mt-1 flex items-center justify-between gap-2">
@@ -131,7 +134,7 @@ export default function BlockedOpuCard({
 
                                 {dateLabel && (
                                     <span
-                                        className="shrink-0 text-[var(--color-light-gray)] text-right -mx-2"
+                                        className="shrink-0 text-[var(--color-light-gray)] text-right"
                                         style={{ fontSize: "var(--text-mini)" }}
                                     >
                                         차단일 {dateLabel}
@@ -141,7 +144,7 @@ export default function BlockedOpuCard({
                         </div>
                     </div>
 
-                    <div className="h-[1px] bg-[var(--color-super-light-gray)] mt-4" />
+                    <div className="h-[1px] bg-[var(--color-super-light-gray)] mt-3" />
                 </div>
             </div>
         </div>

--- a/opu-fe/src/features/blocked-opu/components/BlockedOpuList.tsx
+++ b/opu-fe/src/features/blocked-opu/components/BlockedOpuList.tsx
@@ -56,7 +56,7 @@ export default function BlockedOpuList(props: Props) {
                 />
 
                 <div className="flex items-center justify-between mt-4">
-                    <label className="inline-flex items-center gap-2 text-sm mx-2">
+                    <label className="inline-flex items-center gap-2 text-sm mx-1">
                         <input
                             type="checkbox"
                             className="custom-checkbox shrink-0"
@@ -100,7 +100,7 @@ export default function BlockedOpuList(props: Props) {
             <div className="h-[1px] bg-[var(--color-super-light-gray)] -mx-6" />
 
             {/* 리스트 */}
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2.5">
                 {filtered.map((item) => (
                     <BlockedOpuCard
                         key={item.id}
@@ -114,7 +114,7 @@ export default function BlockedOpuList(props: Props) {
 
                 {filtered.length === 0 && (
                     <div
-                        className="text-center text-sm text-zinc-500 py-10"
+                        className="text-center text-sm py-10"
                         style={{
                             fontSize: "var(--text-sub)",
                             color: "var(--color-light-gray)",


### PR DESCRIPTION
## 🏷️ 연결 이슈

Closes #65

## 🏷️ PR 유형 (라벨 & 커밋 메시지 매핑)

-   🎨 Design / 마크업 → style: 코드 구조/형태 개선

## 📝 PR 내용

차단 OPU 목록 페이지 스타일 수정

## 🔧 작업 내역 / 수정 사항

- 기존

## 📌 참고

- 전/후 비교사진 입니다.
<img width="300" alt="IMG_2821" src="https://github.com/user-attachments/assets/aac6e7bb-424e-4918-a98f-959bd4f5aee2" />
<img width="300" alt="One Point Up 25" src="https://github.com/user-attachments/assets/cededb2c-1ca5-483a-8ade-649166abe829" />

- 기존에는 다른 페이지에 비해 글씨가 크고 div도 유지보수에 용이하지 않게 나누어져 있어서 다시 나누었습니다
- 이외에는 변동사항 없습니다

## ✅ 체크리스트

-   [ ] 코드 작성 및 테스트 완료
-   [ ] 기존 기능 영향 없음 확인
-   [ ] 문서 및 주석 최신화
